### PR TITLE
Disabling code or data flash. Intel HEX support.

### DIFF
--- a/src/main_g10.c
+++ b/src/main_g10.c
@@ -41,6 +41,10 @@ const char *usage =
     "\t\t\tn=2 Single-wire UART, Reset by RTS\n"
     "\t\t\tdefault: n=1\n"
     "\t-n\tInvert reset\n"
+    "\t-f n\tSet file format\n"
+    "\t\t\tn=0 S-record\n"
+    "\t\t\tn=1 Intel Hex\n"
+    "\t\t\tdefault: n=0\n"
     "\t-t baud\tStart terminal with specified baudrate\n"
     "\t-v\tVerbose mode\n"
     "\t-h\tDisplay help\n";
@@ -55,6 +59,7 @@ int main(int argc, char *argv[])
     char invert_reset = 0;
     char terminal = 0;
     int terminal_baud = 0;
+    char file_format = 0;
 
     char *endp;
     int opt;
@@ -73,6 +78,17 @@ int main(int argc, char *argv[])
                 || MODE_MAX_VALUE < mode)
             {
                 fprintf(stderr, "Invalid mode\n");
+                printf("%s", usage);
+                return EINVAL;
+            }
+            break;
+        case 'f':
+            file_format = strtol(optarg, &endp, 10);
+            if (optarg == endp
+                || FILE_FORMAT_MAX_VALUE < mode
+                || FILE_FORMAT_MIN_VALUE > mode)
+            {
+                fprintf(stderr, "Invalid file format\n");
                 printf("%s", usage);
                 return EINVAL;
             }
@@ -209,7 +225,14 @@ int main(int argc, char *argv[])
             {
                 printf("Read file \"%s\"\n", filename);
             }
-            rc = srec_read(filename, code, codesize, NULL, 0);
+            if (FILE_FORMAT_IHEX == file_format)
+            {
+                rc = ihex_read(filename, code, codesize, NULL, 0);
+            }
+            else
+            {
+                rc = srec_read(filename, code, codesize, NULL, 0);
+            }
             if (0 != rc)
             {
                 fprintf(stderr, "Read failed\n");

--- a/src/srec.h
+++ b/src/srec.h
@@ -21,10 +21,19 @@
 #define SREC_H__
 
 int srec_read(const char *filename, void *code, unsigned int code_len, void *data, unsigned int data_len);
+int ihex_read(const char *filename, void *code, unsigned int code_len, void *data, unsigned int data_len);
+
 
 #define SREC_NO_ERROR           (0)
 #define SREC_IO_ERROR           (-1)
 #define SREC_FORMAT_ERROR       (-2)
 #define SREC_MEMORY_ERROR       (-3)
+
+#define FILE_FORMAT_SREC        0
+#define FILE_FORMAT_IHEX        1
+
+#define FILE_FORMAT_MIN_VALUE   0
+#define FILE_FORMAT_MAX_VALUE   1
+
 
 #endif // SREC_H__


### PR DESCRIPTION
I added the possibility to disable data flash or code flash operations as commented on issue #9 

I added two commandline options. -x and -y.
And two variables char nodata and char nocode.
Using -x will disable any data flash operations.
Using -y will disable any code flash operations.

Also I added a support for Intel HEX format.
Previously I had to use srec_cat to convert hex files to s-record before using fl78flash.
So I made it possible to use the files directly.
A new comand line option is -f.
-f 0 is S-record.
-f 1 is Intel HEX
default is 0 (S-record).
I added ihex_read() function which is a copy or srec_read() slightly modified for the Intel HEX format.

