### PR TITLE
Add basic support for RL78/G23 and similar chips

### DIFF
--- a/src/main.c
+++ b/src/main.c
@@ -22,6 +22,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
+#include <stdbool.h>
 #include <stdint.h>
 #include "rl78.h"
 #include "serial.h"
@@ -242,6 +243,7 @@ int main(int argc, char *argv[])
             }
             char device_name[11];
             unsigned int code_size, data_size;
+            bool is_g23;
             rc = rl78_cmd_silicon_signature(fd, device_name, &code_size, &data_size);
             if (0 > rc)
             {
@@ -249,6 +251,7 @@ int main(int argc, char *argv[])
                 retcode = EIO;
                 break;
             }
+            is_g23 = !memcmp(device_name, "R7F", 3);
             if (1 == display_info)
             {
                 printf("Device: %s\n"
@@ -269,7 +272,7 @@ int main(int argc, char *argv[])
                 {
                     printf("Erase code flash\n");
                 }
-                rc = rl78_erase(fd, CODE_OFFSET, code_size);
+                rc = rl78_erase(fd, CODE_OFFSET, code_size, is_g23);
                 if (0 != rc)
                 {
                     fprintf(stderr, "Code flash erase failed\n");
@@ -283,7 +286,7 @@ int main(int argc, char *argv[])
                 {
                     printf("Erase data flash\n");
                 }
-                rc = rl78_erase(fd, DATA_OFFSET, data_size);
+                rc = rl78_erase(fd, DATA_OFFSET, data_size, is_g23);
                 if (0 != rc)
                 {
                     fprintf(stderr, "Data flash erase failed\n");
@@ -326,7 +329,7 @@ int main(int argc, char *argv[])
                 {
                     printf("Write code flash\n");
                 }
-                rc = rl78_program(fd, CODE_OFFSET, code, code_size);
+                rc = rl78_program(fd, CODE_OFFSET, code, code_size, is_g23);
                 if (0 != rc)
                 {
                     fprintf(stderr, "Code flash write failed\n");
@@ -340,7 +343,7 @@ int main(int argc, char *argv[])
                 {
                     printf("Write data flash\n");
                 }
-                rc = rl78_program(fd, DATA_OFFSET, data, data_size);
+                rc = rl78_program(fd, DATA_OFFSET, data, data_size, is_g23);
                 if (0 != rc)
                 {
                     fprintf(stderr, "Data flash write failed\n");
@@ -354,7 +357,7 @@ int main(int argc, char *argv[])
                 {
                     printf("Verify Code flash\n");
                 }
-                rc = rl78_verify(fd, CODE_OFFSET, code, code_size);
+                rc = rl78_verify(fd, CODE_OFFSET, code, code_size, is_g23);
                 if (0 != rc)
                 {
                     fprintf(stderr, "Code flash verification failed\n");
@@ -368,7 +371,7 @@ int main(int argc, char *argv[])
                 {
                     printf("Verify Data flash\n");
                 }
-                rc = rl78_verify(fd, DATA_OFFSET, data, data_size);
+                rc = rl78_verify(fd, DATA_OFFSET, data, data_size, is_g23);
                 if (0 != rc)
                 {
                     fprintf(stderr, "Data flash verification failed\n");

--- a/src/main.c
+++ b/src/main.c
@@ -23,6 +23,7 @@
 #include <string.h>
 #include <errno.h>
 #include <stdint.h>
+#include <assert.h>
 #include "rl78.h"
 #include "serial.h"
 #include "srec.h"
@@ -295,6 +296,14 @@ int main(int argc, char *argv[])
                     retcode = EINVAL;
                     break;
                 }
+            }
+            if (0 == block_size_table[proto_ver])
+            {
+                fprintf(stderr, "Error: invalid protocol version ID %d, I don't "
+                        "know what flash block size corresponds to this version!\n",
+                        proto_ver);
+                retcode = EINVAL;
+                break;
             }
             if (1 == display_info)
             {

--- a/src/main.c
+++ b/src/main.c
@@ -22,7 +22,6 @@
 #include <unistd.h>
 #include <string.h>
 #include <errno.h>
-#include <stdbool.h>
 #include <stdint.h>
 #include "rl78.h"
 #include "serial.h"
@@ -51,6 +50,12 @@ const char *usage =
     "\t\t\tn=3 Single-wire UART, Reset by RTS\n"
     "\t\t\tn=4 Two-wire UART, Reset by RTS\n"
     "\t\t\tdefault: n=1\n"
+    "\t-P n\tSet protocol version\n"
+    "\t\t\tn=-1 Try to autodetect the protocol version from the unit's Silicon Signature\n"
+    "\t\t\tn=0 Protocol A, for most RL78 units\n"
+    "\t\t\tn=2 Protocol C, for RL78/G23 units\n"
+    "\t\t\tn=3 Protocol D, for RL78/F24 units\n"
+    "\t\t\tdefault: n=-1\n"
     "\t-n\tInvert reset\n"
     "\t-p v\tSpecify power supply voltage\n"
     "\t\t\tdefault: 3.3\n"
@@ -73,10 +78,11 @@ int main(int argc, char *argv[])
     int terminal_baud = 0;
     char nodata = 0;
     char nocode = 0;
+    int proto_ver = -1;
 
     char *endp;
     int opt;
-    while ((opt = getopt(argc, argv, "xyab:cvwrdeim:np:t:h?")) != -1)
+    while ((opt = getopt(argc, argv, "xyab:cvwrdeim:np:P:t:h?")) != -1)
     {
         switch (opt)
         {
@@ -134,6 +140,19 @@ int main(int argc, char *argv[])
             {
                 fprintf(stderr, "Operating voltage is out of range. Operating voltage must be in range %1.1fV..%1.1fV.\n",
                         RL78_MIN_VOLTAGE, RL78_MAX_VOLTAGE);
+                return EINVAL;
+            }
+            break;
+        case 'P':
+            if (1 != sscanf(optarg, "%d", &proto_ver))
+            {
+                fprintf(stderr, "Invalid protocol version ID value: %s\n", optarg);
+                printf("%s", usage);
+                return EINVAL;
+            }
+            if (1 == proto_ver || PROTOCOL_VERSION_A > proto_ver || PROTOCOL_VERSION_D < proto_ver)
+            {
+                fprintf(stderr, "Protocol version ID is out of range. See the output of `-h' for the list of allowed values.\n");
                 return EINVAL;
             }
             break;
@@ -243,7 +262,6 @@ int main(int argc, char *argv[])
             }
             char device_name[11];
             unsigned int code_size, data_size;
-            bool is_g23;
             rc = rl78_cmd_silicon_signature(fd, device_name, &code_size, &data_size);
             if (0 > rc)
             {
@@ -251,7 +269,33 @@ int main(int argc, char *argv[])
                 retcode = EIO;
                 break;
             }
-            is_g23 = !memcmp(device_name, "R7F", 3);
+            if (-1 == proto_ver)
+            {
+                if (!memcmp(device_name, "R7F", 3))
+                {
+                    /* NOTE: this isn't too precise, that's why a separate
+                     * optional flag for overriding is provided */
+                    if (device_name[4] == '2') /* RL78/F24: eg. R7F124 */
+                    {
+                        proto_ver = PROTOCOL_VERSION_D;
+                    }
+                    else /* RL78/G23: eg. R7F100 */
+                    {
+                        proto_ver = PROTOCOL_VERSION_C;
+                    }
+                }
+                else if (!memcmp(device_name, "R5F", 3))
+                {
+                    proto_ver = PROTOCOL_VERSION_A;
+                }
+                else
+                {
+                    fprintf(stderr, "Error: unknown device name '%s', please set "
+                            "the protocol version manually.\n", device_name);
+                    retcode = EINVAL;
+                    break;
+                }
+            }
             if (1 == display_info)
             {
                 printf("Device: %s\n"
@@ -272,7 +316,7 @@ int main(int argc, char *argv[])
                 {
                     printf("Erase code flash\n");
                 }
-                rc = rl78_erase(fd, CODE_OFFSET, code_size, is_g23);
+                rc = rl78_erase(fd, CODE_OFFSET, code_size, proto_ver);
                 if (0 != rc)
                 {
                     fprintf(stderr, "Code flash erase failed\n");
@@ -286,7 +330,7 @@ int main(int argc, char *argv[])
                 {
                     printf("Erase data flash\n");
                 }
-                rc = rl78_erase(fd, DATA_OFFSET, data_size, is_g23);
+                rc = rl78_erase(fd, DATA_OFFSET, data_size, proto_ver);
                 if (0 != rc)
                 {
                     fprintf(stderr, "Data flash erase failed\n");
@@ -329,7 +373,7 @@ int main(int argc, char *argv[])
                 {
                     printf("Write code flash\n");
                 }
-                rc = rl78_program(fd, CODE_OFFSET, code, code_size, is_g23);
+                rc = rl78_program(fd, CODE_OFFSET, code, code_size, proto_ver);
                 if (0 != rc)
                 {
                     fprintf(stderr, "Code flash write failed\n");
@@ -343,7 +387,7 @@ int main(int argc, char *argv[])
                 {
                     printf("Write data flash\n");
                 }
-                rc = rl78_program(fd, DATA_OFFSET, data, data_size, is_g23);
+                rc = rl78_program(fd, DATA_OFFSET, data, data_size, proto_ver);
                 if (0 != rc)
                 {
                     fprintf(stderr, "Data flash write failed\n");
@@ -357,7 +401,7 @@ int main(int argc, char *argv[])
                 {
                     printf("Verify Code flash\n");
                 }
-                rc = rl78_verify(fd, CODE_OFFSET, code, code_size, is_g23);
+                rc = rl78_verify(fd, CODE_OFFSET, code, code_size, proto_ver);
                 if (0 != rc)
                 {
                     fprintf(stderr, "Code flash verification failed\n");
@@ -371,7 +415,7 @@ int main(int argc, char *argv[])
                 {
                     printf("Verify Data flash\n");
                 }
-                rc = rl78_verify(fd, DATA_OFFSET, data, data_size, is_g23);
+                rc = rl78_verify(fd, DATA_OFFSET, data, data_size, proto_ver);
                 if (0 != rc)
                 {
                     fprintf(stderr, "Data flash verification failed\n");

--- a/src/rl78.c
+++ b/src/rl78.c
@@ -20,6 +20,7 @@
 #include <unistd.h>
 #include <string.h>
 #include <stdio.h>
+#include <assert.h>
 #include "wait_kbhit.h"
 
 #include "serial.h"
@@ -27,6 +28,13 @@
 
 extern int verbose_level;
 static unsigned char communication_mode;
+
+const unsigned int block_size_table[] = {
+    [PROTOCOL_VERSION_A] = 1024,
+    [PROTOCOL_VERSION_C] = 2048,
+    [PROTOCOL_VERSION_D] = 2048,
+};
+
 
 static void rl78_set_reset(port_handle_t fd, int mode, int value)
 {
@@ -651,7 +659,8 @@ int allFFs(const void *mem, unsigned int size)
 
 int rl78_program(port_handle_t fd, unsigned int address, const void *data, unsigned int size, int proto_ver)
 {
-    unsigned int blksz = (proto_ver >= PROTOCOL_VERSION_C) ? FLASH_BLOCK_SIZE_G2X : FLASH_BLOCK_SIZE_G1X;
+    unsigned int blksz = block_size_table[proto_ver];
+    assert(blksz); /* shouldn't happen due to guards in main.c */
 
     // Make sure size is aligned to flash block boundary
     unsigned int i = size & ~(blksz - 1);
@@ -714,7 +723,8 @@ int rl78_program(port_handle_t fd, unsigned int address, const void *data, unsig
 
 int rl78_erase(port_handle_t fd, unsigned int start_address, unsigned int size, int proto_ver)
 {
-    unsigned int blksz = (proto_ver >= PROTOCOL_VERSION_C) ? FLASH_BLOCK_SIZE_G2X : FLASH_BLOCK_SIZE_G1X;
+    unsigned int blksz = block_size_table[proto_ver];
+    assert(blksz); /* shouldn't happen due to guards in main.c */
 
     // Make sure size is aligned to flash block boundary
     unsigned int i = size & ~(blksz - 1);
@@ -763,7 +773,8 @@ int rl78_erase(port_handle_t fd, unsigned int start_address, unsigned int size, 
 
 int rl78_verify(port_handle_t fd, unsigned int address, const void *data, unsigned int size, int proto_ver)
 {
-    unsigned int blksz = (proto_ver >= PROTOCOL_VERSION_C) ? FLASH_BLOCK_SIZE_G2X : FLASH_BLOCK_SIZE_G1X;
+    unsigned int blksz = block_size_table[proto_ver];
+    assert(blksz); /* shouldn't happen due to guards in main.c */
 
     // Make sure size is aligned to flash block boundary
     unsigned int i = size & ~(blksz - 1);

--- a/src/rl78.c
+++ b/src/rl78.c
@@ -17,12 +17,14 @@
  * IN THE SOFTWARE.                                                                                                  *
  *********************************************************************************************************************/
 
-#include "serial.h"
-#include "rl78.h"
 #include <unistd.h>
 #include <string.h>
+#include <stdbool.h>
 #include <stdio.h>
 #include "wait_kbhit.h"
+
+#include "serial.h"
+#include "rl78.h"
 
 extern int verbose_level;
 static unsigned char communication_mode;
@@ -262,7 +264,7 @@ int rl78_cmd_baud_rate_set(port_handle_t fd, int baud, float voltage)
     int rc = rl78_recv(fd, &data, &len, 3);
     if (RESPONSE_OK != rc)
     {
-        fprintf(stderr, "FAILED\n");
+        fprintf(stderr, "FAILED baud rate set\n");
         return rc;
     }
     if (STATUS_ACK != data[0])
@@ -457,7 +459,7 @@ int rl78_cmd_checksum(port_handle_t fd, unsigned int address_start, unsigned int
     return rc;
 }
 
-int rl78_cmd_programming(port_handle_t fd, unsigned int address_start, unsigned int address_end, const void *rom)
+int rl78_cmd_programming(port_handle_t fd, unsigned int address_start, unsigned int address_end, const void *rom, bool is_g23)
 {
     if (3 <= verbose_level)
     {
@@ -472,7 +474,7 @@ int rl78_cmd_programming(port_handle_t fd, unsigned int address_start, unsigned 
     int rc = rl78_recv(fd, &data, &len, 1);
     if (RESPONSE_OK != rc)
     {
-        fprintf(stderr, "FAILED\n");
+        fprintf(stderr, "FAILED (no response)\n");
         return rc;
     }
     if (STATUS_ACK != data[0])
@@ -510,7 +512,7 @@ int rl78_cmd_programming(port_handle_t fd, unsigned int address_start, unsigned 
         rc = rl78_recv(fd, &data, &len, 2);
         if (RESPONSE_OK != rc)
         {
-            fprintf(stderr, "FAILED\n");
+            fprintf(stderr, "FAILED (bad response for block)\n");
             return rc;
         }
         if (STATUS_ACK != data[0])
@@ -526,16 +528,19 @@ int rl78_cmd_programming(port_handle_t fd, unsigned int address_start, unsigned 
     }
     usleep(final_delay);
     // Receive status of completion
-    rc = rl78_recv(fd, &data, &len, 1);
-    if (RESPONSE_OK != rc)
+    if (!is_g23)
     {
-        fprintf(stderr, "FAILED\n");
-        return rc;
+        rc = rl78_recv(fd, &data, &len, 1);
+        if (RESPONSE_OK != rc)
+        {
+            fprintf(stderr, "FAILED (response not ok)\n");
+            return rc;
         }
-    if (STATUS_ACK != data[0])
-    {
-        fprintf(stderr, "ACK not received\n");
-        return data[0];
+        if (STATUS_ACK != data[0])
+        {
+            fprintf(stderr, "ACK not received\n");
+            return data[0];
+        }
     }
     if (3 <= verbose_level)
     {
@@ -645,22 +650,24 @@ int allFFs(const void *mem, unsigned int size)
     return 1;
 }
 
-int rl78_program(port_handle_t fd, unsigned int address, const void *data, unsigned int size)
+int rl78_program(port_handle_t fd, unsigned int address, const void *data, unsigned int size, bool is_g23)
 {
+    unsigned int blksz = is_g23 ? FLASH_BLOCK_SIZE_G23 : FLASH_BLOCK_SIZE;
+
     // Make sure size is aligned to flash block boundary
-    unsigned int i = size & ~(FLASH_BLOCK_SIZE - 1);
+    unsigned int i = size & ~(blksz - 1);
     const unsigned char *mem = (const unsigned char*)data;
     int rc = 0;;
-    for (; i; i -= FLASH_BLOCK_SIZE)
+    for (; i; i -= blksz)
     {
-        if (!allFFs(mem, FLASH_BLOCK_SIZE))
+        if (!allFFs(mem, blksz))
         {
             if (3 <= verbose_level)
             {
                 printf("Program block %06X\n", address);
             }
             // Check if block is ready to program new content
-            rc = rl78_cmd_block_blank_check(fd, address, address + FLASH_BLOCK_SIZE - 1);
+            rc = rl78_cmd_block_blank_check(fd, address, address + blksz - 1);
             if (0 > rc)
             {
                 fprintf(stderr, "Block Blank Check failed (%06X)\n", address);
@@ -677,7 +684,7 @@ int rl78_program(port_handle_t fd, unsigned int address, const void *data, unsig
                 }
             }
             // Write new content
-            rc = rl78_cmd_programming(fd, address, address + FLASH_BLOCK_SIZE - 1, mem);
+            rc = rl78_cmd_programming(fd, address, address + blksz - 1, mem, is_g23);
             if (0 > rc)
             {
                 fprintf(stderr, "Programming failed (%06X)\n", address);
@@ -696,8 +703,8 @@ int rl78_program(port_handle_t fd, unsigned int address, const void *data, unsig
                 printf("No data at block %06X\n", address);
             }
         }
-        mem += FLASH_BLOCK_SIZE;
-        address += FLASH_BLOCK_SIZE;
+        mem += blksz;
+        address += blksz;
     }
     if (2 == verbose_level)
     {
@@ -706,15 +713,17 @@ int rl78_program(port_handle_t fd, unsigned int address, const void *data, unsig
     return rc;
 }
 
-int rl78_erase(port_handle_t fd, unsigned int start_address, unsigned int size)
+int rl78_erase(port_handle_t fd, unsigned int start_address, unsigned int size, bool is_g23)
 {
+    unsigned int blksz = is_g23 ? FLASH_BLOCK_SIZE_G23 : FLASH_BLOCK_SIZE;
+
     // Make sure size is aligned to flash block boundary
-    unsigned int i = size & ~(FLASH_BLOCK_SIZE - 1);
+    unsigned int i = size & ~(blksz - 1);
     unsigned int address = start_address;
     int rc = 0;
-    for (; i; i -= FLASH_BLOCK_SIZE)
+    for (; i; i -= blksz)
     {
-        rc = rl78_cmd_block_blank_check(fd, address, address + FLASH_BLOCK_SIZE - 1);
+        rc = rl78_cmd_block_blank_check(fd, address, address + blksz - 1);
         if (0 > rc)
         {
             fprintf(stderr, "Block Blank Check failed (%06X)\n", address);
@@ -744,7 +753,7 @@ int rl78_erase(port_handle_t fd, unsigned int start_address, unsigned int size)
                 fflush(stdout);
             }
         }
-        address += FLASH_BLOCK_SIZE;
+        address += blksz;
     }
     if (2 == verbose_level)
     {
@@ -753,22 +762,24 @@ int rl78_erase(port_handle_t fd, unsigned int start_address, unsigned int size)
     return rc;
 }
 
-int rl78_verify(port_handle_t fd, unsigned int address, const void *data, unsigned int size)
+int rl78_verify(port_handle_t fd, unsigned int address, const void *data, unsigned int size, bool is_g23)
 {
+    unsigned int blksz = is_g23 ? FLASH_BLOCK_SIZE_G23 : FLASH_BLOCK_SIZE;
+
     // Make sure size is aligned to flash block boundary
-    unsigned int i = size & ~(FLASH_BLOCK_SIZE - 1);
+    unsigned int i = size & ~(blksz - 1);
     const unsigned char *mem = (const unsigned char*)data;
     int rc = 0;
-    for (; i; i -= FLASH_BLOCK_SIZE)
+    for (; i; i -= blksz)
     {
         if (3 <= verbose_level)
         {
             printf("Verify block %06X\n", address);
         }
-        if (allFFs(mem, FLASH_BLOCK_SIZE))
+        if (allFFs(mem, blksz))
         {
             // Check if block is blank
-            rc = rl78_cmd_block_blank_check(fd, address, address + FLASH_BLOCK_SIZE - 1);
+            rc = rl78_cmd_block_blank_check(fd, address, address + blksz - 1);
             if (0 > rc)
             {
                 fprintf(stderr, "Block Blank Check failed (%06X)\n", address);
@@ -788,7 +799,7 @@ int rl78_verify(port_handle_t fd, unsigned int address, const void *data, unsign
         else
         {
             // If block is not blank
-            rc = rl78_cmd_verify(fd, address, address + FLASH_BLOCK_SIZE - 1, mem);
+            rc = rl78_cmd_verify(fd, address, address + blksz - 1, mem);
             if (0 != rc)
             {
                 fprintf(stderr, "Block content does not match (%06X)\n", address);
@@ -800,8 +811,8 @@ int rl78_verify(port_handle_t fd, unsigned int address, const void *data, unsign
                 fflush(stdout);
             }
         }
-        mem += FLASH_BLOCK_SIZE;
-        address += FLASH_BLOCK_SIZE;
+        mem += blksz;
+        address += blksz;
     }
     if (2 == verbose_level)
     {

--- a/src/rl78.h
+++ b/src/rl78.h
@@ -53,8 +53,6 @@
 #define RL78_BAUD_500000     0x02
 #define RL78_BAUD_1000000    0x03
 
-#define FLASH_BLOCK_SIZE_G1X    1024
-#define FLASH_BLOCK_SIZE_G2X    2048
 #define CODE_OFFSET             (0U)
 #define DATA_OFFSET             (0x000F1000U)
 
@@ -87,6 +85,8 @@
 #define PROTOCOL_VERSION_D 3 /* RL78/F24 */
 
 #include "serial.h"
+
+extern const unsigned int block_size_table[];
 
 int rl78_reset_init(port_handle_t fd, int wait, int baud, int mode, float voltage);
 int rl78_reset(port_handle_t fd, int mode);

--- a/src/rl78.h
+++ b/src/rl78.h
@@ -53,8 +53,8 @@
 #define RL78_BAUD_500000     0x02
 #define RL78_BAUD_1000000    0x03
 
-#define FLASH_BLOCK_SIZE        1024
-#define FLASH_BLOCK_SIZE_G23    2048
+#define FLASH_BLOCK_SIZE_G1X    1024
+#define FLASH_BLOCK_SIZE_G2X    2048
 #define CODE_OFFSET             (0U)
 #define DATA_OFFSET             (0x000F1000U)
 
@@ -81,6 +81,11 @@
 #define MODE_MIN_VALUE    0
 #define MODE_INVERT_RESET 0x80
 
+#define PROTOCOL_VERSION_A 0 /* most RL78 chips */
+/* Protocol B = ??? Is this the G10 protocol? */
+#define PROTOCOL_VERSION_C 2 /* RL78/G23 */
+#define PROTOCOL_VERSION_D 3 /* RL78/F24 */
+
 #include "serial.h"
 
 int rl78_reset_init(port_handle_t fd, int wait, int baud, int mode, float voltage);
@@ -94,11 +99,11 @@ int rl78_cmd_silicon_signature(port_handle_t fd, char device_name[11], unsigned 
 int rl78_cmd_block_erase(port_handle_t fd, unsigned int address);
 int rl78_cmd_block_blank_check(port_handle_t fd, unsigned int address_start, unsigned int address_end);
 int rl78_cmd_checksum(port_handle_t fd, unsigned int address_start, unsigned int address_end);
-int rl78_cmd_programming(port_handle_t fd, unsigned int address_start, unsigned int address_end, const void *rom, bool is_g23);
+int rl78_cmd_programming(port_handle_t fd, unsigned int address_start, unsigned int address_end, const void *rom, int proto_ver);
 unsigned int rl78_checksum(const void *rom, unsigned int len);
 int rl78_cmd_verify(port_handle_t fd, unsigned int address_start, unsigned int address_end, const void *rom);
-int rl78_program(port_handle_t fd, unsigned int address, const void *data, unsigned int size, bool is_g23);
-int rl78_erase(port_handle_t fd, unsigned int start_address, unsigned int size, bool is_g23);
-int rl78_verify(port_handle_t fd, unsigned int address, const void *data, unsigned int size, bool is_g23);
+int rl78_program(port_handle_t fd, unsigned int address, const void *data, unsigned int size, int proto_ver);
+int rl78_erase(port_handle_t fd, unsigned int start_address, unsigned int size, int proto_ver);
+int rl78_verify(port_handle_t fd, unsigned int address, const void *data, unsigned int size, int proto_ver);
 
 #endif  // RL78_H__

--- a/src/rl78.h
+++ b/src/rl78.h
@@ -54,6 +54,7 @@
 #define RL78_BAUD_1000000    0x03
 
 #define FLASH_BLOCK_SIZE        1024
+#define FLASH_BLOCK_SIZE_G23    2048
 #define CODE_OFFSET             (0U)
 #define DATA_OFFSET             (0x000F1000U)
 
@@ -93,11 +94,11 @@ int rl78_cmd_silicon_signature(port_handle_t fd, char device_name[11], unsigned 
 int rl78_cmd_block_erase(port_handle_t fd, unsigned int address);
 int rl78_cmd_block_blank_check(port_handle_t fd, unsigned int address_start, unsigned int address_end);
 int rl78_cmd_checksum(port_handle_t fd, unsigned int address_start, unsigned int address_end);
-int rl78_cmd_programming(port_handle_t fd, unsigned int address_start, unsigned int address_end, const void *rom);
+int rl78_cmd_programming(port_handle_t fd, unsigned int address_start, unsigned int address_end, const void *rom, bool is_g23);
 unsigned int rl78_checksum(const void *rom, unsigned int len);
 int rl78_cmd_verify(port_handle_t fd, unsigned int address_start, unsigned int address_end, const void *rom);
-int rl78_program(port_handle_t fd, unsigned int address, const void *data, unsigned int size);
-int rl78_erase(port_handle_t fd, unsigned int start_address, unsigned int size);
-int rl78_verify(port_handle_t fd, unsigned int address, const void *data, unsigned int size);
+int rl78_program(port_handle_t fd, unsigned int address, const void *data, unsigned int size, bool is_g23);
+int rl78_erase(port_handle_t fd, unsigned int start_address, unsigned int size, bool is_g23);
+int rl78_verify(port_handle_t fd, unsigned int address, const void *data, unsigned int size, bool is_g23);
 
 #endif  // RL78_H__


### PR DESCRIPTION
Flash block size has doubled, which broke existing code

Some features are still missing, eg. security ID authentication, extra
option bytes, ...

As the code for RL78/G13 etc. chips didn't support most of these extra
commands (eg. flash shield window stuff), I didn't add these either.